### PR TITLE
Fix app to use in api/http_ctrl.py

### DIFF
--- a/api/http_web.py
+++ b/api/http_web.py
@@ -1,6 +1,6 @@
 from bottle import Bottle
 
-from app.examples.dice.app import app
+from app import app
 
 web_server = Bottle()
 


### PR DESCRIPTION
Hi together,
the import of the app instance in `api/http_web.py` is using one of the example apps instead of the app exposed in `app/__init__.py`.

Best,
Zeno