### PR TITLE
Add handle errors during transition and state execution

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -1,5 +1,6 @@
 import datetime
 import threading
+import traceback
 from time import sleep
 
 from typing import Dict, List, Tuple
@@ -63,8 +64,17 @@ class App:
         if not self.current_state:
             raise RuntimeError('initial state not found')
 
-        self.thread = threading.Thread(target=self.run)
+        self.thread = threading.Thread(target=self.guarded_run)
         self.thread.start()
+
+    def guarded_run(self):
+        try:
+            self.run()
+        except Exception as e:  # catch all  # noqa
+            self.log(traceback.format_exc())
+            self.status_message = 'ERROR. See log for stack trace.'
+            self.status_state = STATE_ERROR
+            self.status_finished = True
 
     def run(self):
         while True:

--- a/engine/app.py
+++ b/engine/app.py
@@ -1,6 +1,7 @@
 import datetime
 import threading
 import traceback
+
 from time import sleep
 
 from typing import Dict, List, Tuple


### PR DESCRIPTION
Hi together,
this PR is a proposal to catch errors that may happen during the transition and running of states of the state machine. Otherwise raising an e.g. RuntimeException will not stop the execution but show the app as running. 

The commits add a method called `guarded_run` to `engine.app.App` which is used as a replacement for the `run` method. This method wraps the `run` method inside a catch-all try-except block. Any exception raised but not handled inside `run` will lead to dumping a traceback of the error to the logs, setting the `status_state` to `STATE_ERROR`, setting a status message, and setting the `status_finished` attribute to `True`.

The std-lib module `traceback`, which mimics the behavior of the Python interpreter, is used to create the error traceback for the logs.

Best,
Zeno 