### PR TITLE
Fix handling of smpc and destination for next element on multiple handle_outgoing elements

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -101,8 +101,8 @@ class App:
             self.status_smpc = None
         else:
             self.status_available = True
-            self.status_destination = self.data_outgoing[0][1]
-            self.status_smpc = self.default_smpc if self.data_outgoing[0][2] else None
+            self.status_smpc = self.default_smpc if self.data_outgoing[0][1] else None
+            self.status_destination = self.data_outgoing[0][2]
         return data[0]
 
     def _register_state(self, name, state, participant, coordinator, **kwargs):


### PR DESCRIPTION
Hi together,

there seems to be a bug in either the parsing in `App.handle_outgoing` or how data is added in multiple `AppState` methods:

The tuple appended to the data_outgoing list in `AppState.send_data_to_participant`, `AppState.send_data_to_coordinator` and `AppState.broadcast_data` has the structure `(data, smpc, destination)`. This is not reflected in the parsing of the tuple in `App.handle_outgoing`, where the smpc field is read into the destination attr and the destination field is read into the smpc attr. 

This commit fixes this behavior in `App.handle_outgoing`.

Best,
Zeno