### PR TITLE
Fix behavior when running with only one client

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -180,14 +180,14 @@ class AppState:
         self.app.register_transition(f'{self.name}_{name}', self.name, target, participant, coordinator)
 
     def gather_data(self):
-        return self.await_data(len(self.app.clients))
+        return self.await_data(len(self.app.clients), unwrap=False)
 
-    def await_data(self, n: int = 1):
+    def await_data(self, n: int = 1, unwrap: bool = True):
         while True:
             if len(self.app.data_incoming) >= n:
                 data = self.app.data_incoming[:n]
                 self.app.data_incoming = self.app.data_incoming[n:]
-                if n == 1:
+                if unwrap and n == 1:
                     return data[0][0]
                 else:
                     return data[0]


### PR DESCRIPTION
Hi,
await data has two different scenarios I use it with. 1) Listening for a broadcast/direct message; this is where we expect only data from one client; 2) Inside of gather_data

In case 1 data is unwrapped. Calling it from 2 normally doesn't unwrap it, only in the case of running with only one client, it is unwrapped. I think this is unintentional.

Commit:
When running with only one client for testing purposes, gather_data behaves differently as it gives the unwrapped data. Specific app code should not be forced to handle this.
The await_data method should keep its behavior in the case that only data from one client is expected when listening to a coordinator broadcast. For that, a default value is set.

Best,
Zeno